### PR TITLE
Fix runtime browser behavior for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,27 @@ jobs:
 
       - name: Build distributions
         run: uv build
+
+  browser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Install dependencies
+        run: uv sync --all-groups --python 3.13
+
+      - name: Run local browser tests
+        env:
+          SELENIUMTABS_FAIL_BROWSER_SKIP: "1"
+        run: uv run pytest tests/test_local_browser.py -q

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seleniumtabs"
-version = "2.1.1"
+version = "2.1.2"
 description = "Selenium with tab management in Python"
 readme = "README.md"
 requires-python = ">=3.13,<4.0"

--- a/seleniumtabs/browser.py
+++ b/seleniumtabs/browser.py
@@ -24,6 +24,7 @@ class Browser:
         user_agent: str | None = None,
         headless: bool = False,
         full_screen: bool = True,
+        page_load_timeout: int = 60,
     ):
         logger.info(f"Initializing Browser with name: {name}")
         self.name = name
@@ -35,6 +36,7 @@ class Browser:
             implicit_wait=implicit_wait,
             user_agent=user_agent,
             full_screen=full_screen,
+            page_load_timeout=page_load_timeout,
         )
         logger.info("Session created successfully")
 

--- a/seleniumtabs/session.py
+++ b/seleniumtabs/session.py
@@ -97,6 +97,10 @@ class Session:
         if self.headless:
             driver_options.add_argument("--headless")
 
+        if self.browser == "FireFox":
+            driver_options.set_preference("general.useragent.override", self.user_agent)
+            return driver_options
+
         driver_options.add_argument("--disable-gpu")
         driver_options.add_argument("--disable-extensions")
         driver_options.add_argument("--no-sandbox")

--- a/seleniumtabs/tabs.py
+++ b/seleniumtabs/tabs.py
@@ -68,10 +68,10 @@ class Tab:
     __repr__ = __str__
 
     def __getattribute__(self, item):
-        with contextlib.suppress(Exception):
+        try:
             return super().__getattribute__(item)
-
-        return getattr(self.driver, item)
+        except AttributeError:
+            return getattr(self.driver, item)
 
     def __del__(self):
         self.close()
@@ -315,7 +315,10 @@ class Tab:
 
     @staticmethod
     def element_center(element):
-        pass
+        return {
+            "x": element.location["x"] + element.size["width"] / 2,
+            "y": element.location["y"] + element.size["height"] / 2,
+        }
 
     def run_js(self, script: str, *args) -> Any:
         """Run JavaScript on the page"""

--- a/seleniumtabs/utils/core.py
+++ b/seleniumtabs/utils/core.py
@@ -11,4 +11,4 @@ def find_elements_by_text(element: webelement.WebElement, text):
 
 
 def find_parent_element(element: webelement.WebElement):
-    return element.find_element(by=By.XPATH, value="..']")
+    return element.find_element(by=By.XPATH, value="..")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -42,6 +43,9 @@ def browser() -> Iterator[Browser]:
         with Browser(name="Chrome", implicit_wait=3, headless=True, full_screen=False) as browser:
             yield browser
     except Exception as exc:
-        pytest.skip(f"Chrome browser unavailable for Selenium tests: {exc}")
+        message = f"Chrome browser unavailable for Selenium tests: {exc}"
+        if os.environ.get("SELENIUMTABS_FAIL_BROWSER_SKIP") == "1":
+            pytest.fail(message)
+        pytest.skip(message)
     finally:
         task_scheduler.cancel_all_tasks()

--- a/tests/test_session_cleanup.py
+++ b/tests/test_session_cleanup.py
@@ -1,3 +1,7 @@
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+
+import seleniumtabs.browser as browser_module
 from seleniumtabs.session import Session
 
 
@@ -5,3 +9,56 @@ def test_session_destructor_ignores_missing_driver_after_failed_initialization()
     session = Session.__new__(Session)
 
     assert session.__del__() is None
+
+
+def test_session_builds_chrome_and_firefox_options_without_launching_driver():
+    for browser_name, expected_type in (("Chrome", ChromeOptions), ("FireFox", FirefoxOptions)):
+        session = Session.__new__(Session)
+        session.browser = browser_name
+        session.headless = True
+        session.user_agent = "seleniumtabs-test-agent"
+
+        assert isinstance(session._get_driver_options(), expected_type)
+
+
+def test_browser_forwards_page_load_timeout_to_session(monkeypatch):
+    created_session = {}
+
+    class RecordingSession:
+        def __init__(
+            self,
+            browser_name,
+            implicit_wait,
+            user_agent,
+            headless=False,
+            full_screen=True,
+            page_load_timeout=60,
+        ):
+            created_session.update(
+                {
+                    "browser_name": browser_name,
+                    "implicit_wait": implicit_wait,
+                    "user_agent": user_agent,
+                    "headless": headless,
+                    "full_screen": full_screen,
+                    "page_load_timeout": page_load_timeout,
+                }
+            )
+
+        def close(self):
+            created_session["closed"] = True
+
+    monkeypatch.setattr(browser_module, "Session", RecordingSession)
+
+    browser = browser_module.Browser(name="Chrome", implicit_wait=2, page_load_timeout=7)
+    browser.close()
+
+    assert created_session == {
+        "browser_name": "Chrome",
+        "implicit_wait": 2,
+        "user_agent": None,
+        "headless": False,
+        "full_screen": True,
+        "page_load_timeout": 7,
+        "closed": True,
+    }

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,0 +1,23 @@
+import pytest
+
+from seleniumtabs.exceptions import SeleniumRequestException
+from seleniumtabs.tabs import Tab
+
+
+class ClosedSession:
+    window_handles = []
+
+
+def test_dead_tab_driver_access_raises_request_exception_without_recursing():
+    tab = Tab(ClosedSession(), "missing")
+
+    with pytest.raises(SeleniumRequestException, match="Current window is dead"):
+        _driver = tab.driver
+
+
+def test_element_center_returns_midpoint_from_location_and_size():
+    class Element:
+        location = {"x": 10, "y": 20}
+        size = {"width": 30, "height": 40}
+
+    assert Tab.element_center(Element()) == {"x": 25.0, "y": 40.0}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
+from selenium.webdriver.common.by import By
 
-from seleniumtabs.utils import urls
+from seleniumtabs.utils import core, urls
 from seleniumtabs.wait import duration_to_type, humanized_wait, humanized_wait_duration
 
 
@@ -52,3 +53,13 @@ def test_duration_to_type_uses_word_count_and_variation(monkeypatch):
     monkeypatch.setattr("seleniumtabs.wait.random.uniform", lambda min_value, max_value: 1.0)
 
     assert duration_to_type("hello world", speed=60) == 2.2
+
+
+def test_find_parent_element_uses_parent_xpath():
+    class Element:
+        def find_element(self, by, value):
+            assert by == By.XPATH
+            assert value == ".."
+            return "parent"
+
+    assert core.find_parent_element(Element()) == "parent"

--- a/uv.lock
+++ b/uv.lock
@@ -823,7 +823,7 @@ wheels = [
 
 [[package]]
 name = "seleniumtabs"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "browserjquery" },


### PR DESCRIPTION
## Summary
- Fix dead-tab attribute fallback recursion and add regression coverage.
- Restore Firefox option construction and expose `page_load_timeout` through `Browser`.
- Add browser-backed CI proof, exclude tests from sdists, and bump package version to `2.1.2` for PyPI publication.

## Test plan
- `make check-commit`
- `SELENIUMTABS_FAIL_BROWSER_SKIP=1 uv run pytest tests/test_local_browser.py -q`
- `uv build`


Made with [Cursor](https://cursor.com)