### PR TITLE
Harden browser lifecycle and release 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seleniumtabs"
-version = "2.1.2"
+version = "2.2.0"
 description = "Selenium with tab management in Python"
 readme = "README.md"
 requires-python = ">=3.13,<4.0"

--- a/seleniumtabs/browser.py
+++ b/seleniumtabs/browser.py
@@ -1,8 +1,11 @@
+import contextlib
 import logging
+from collections.abc import Callable
+from typing import Any
 
 from seleniumtabs.browser_management import browser_sessions
 from seleniumtabs.exceptions import SeleniumRequestException
-from seleniumtabs.schedule_tasks import BrowserTaskScheduler, task_scheduler
+from seleniumtabs.schedule_tasks import BrowserTaskScheduler
 from seleniumtabs.session import Session
 from seleniumtabs.tabs import Tab, TabManager
 from seleniumtabs.wait import humanized_wait
@@ -25,22 +28,36 @@ class Browser:
         headless: bool = False,
         full_screen: bool = True,
         page_load_timeout: int = 60,
+        *,
+        driver_factory: Callable[[Any], Any] | None = None,
+        options_factory: Callable[[str], Any] | None = None,
     ):
         logger.info(f"Initializing Browser with name: {name}")
         self.name = name
+        self._closed = False
 
         logger.info("Creating new Session")
-        self._session = Session(
-            name,
-            headless=headless,
-            implicit_wait=implicit_wait,
-            user_agent=user_agent,
-            full_screen=full_screen,
-            page_load_timeout=page_load_timeout,
-        )
+        session_kwargs: dict[str, Any] = {
+            "implicit_wait": implicit_wait,
+            "user_agent": user_agent,
+            "headless": headless,
+            "full_screen": full_screen,
+            "page_load_timeout": page_load_timeout,
+        }
+        if driver_factory is not None:
+            session_kwargs["driver_factory"] = driver_factory
+        if options_factory is not None:
+            session_kwargs["options_factory"] = options_factory
+
+        self._session = Session(name, **session_kwargs)
         logger.info("Session created successfully")
 
-        self._manager: TabManager = TabManager(self._session)
+        self._task_scheduler = BrowserTaskScheduler()
+        self._manager: TabManager = TabManager(
+            self._session,
+            task_scheduler=self._task_scheduler,
+            close_tab=self.close_tab,
+        )
         self.full_screen = full_screen
 
         browser_sessions.add_browser(self)
@@ -56,7 +73,8 @@ class Browser:
 
     def __del__(self) -> None:
         """Destructor to ensure browser cleanup when object is garbage collected"""
-        self.close()
+        with contextlib.suppress(Exception):
+            self.close()
 
     @property
     def tabs(self) -> list[Tab]:
@@ -115,7 +133,7 @@ class Browser:
         """
         if self._manager.exist(tab):
             # Cancel any tasks scheduled for this tab
-            task_scheduler.cancel_tab_tasks(tab)
+            self._task_scheduler.cancel_tab_tasks(tab)
 
             tab.switch()
             self._remove_tab(tab=tab)
@@ -135,16 +153,20 @@ class Browser:
         4. Keeps the browser session active
         """
         # Cancel any scheduled tasks first
-        task_scheduler.cancel_all_tasks()
+        self._task_scheduler.cancel_all_tasks()
 
         for tab in self.tabs:
             tab.close()
 
     def close(self) -> None:
         """Close the browser and clean up all resources"""
+        if getattr(self, "_closed", False):
+            return
+
         try:
             # Cancel any scheduled tasks first
-            task_scheduler.cancel_all_tasks()
+            if hasattr(self, "_task_scheduler"):
+                self._task_scheduler.cancel_all_tasks()
 
             # Close all tabs and clear the manager
             if hasattr(self, "_manager"):
@@ -153,13 +175,12 @@ class Browser:
             # Close the session
             if hasattr(self, "_session"):
                 self._session.close()
-
-            # Remove from browser sessions
+        finally:
+            # Keep the registry from retaining failed or partially closed browsers.
             if hasattr(self, "name"):
-                browser_sessions.browser_sessions = [b for b in browser_sessions.browser_sessions if b != self]
+                browser_sessions.remove_browser(self)
 
-        except Exception:
-            raise
+        self._closed = True
 
     def __contains__(self, item: Tab) -> bool:
         """Check if a tab exists in the browser"""
@@ -192,7 +213,7 @@ class Browser:
 
     @property
     def task_scheduler(self) -> BrowserTaskScheduler:
-        return task_scheduler
+        return self._task_scheduler
 
     def execute_task(self, max_time: int | None = None, sleep_time: float = 1.0) -> None:
         """Execute scheduled tasks.

--- a/seleniumtabs/browser_management.py
+++ b/seleniumtabs/browser_management.py
@@ -10,10 +10,15 @@ class BrowserSessions:
 
     def close_tab(self, tab):
         if browser := self.get_browser_for_tab(tab):
-            browser.close_tab(tab)
+            return browser.close_tab(tab)
+
+        return None
 
     def add_browser(self, br):
         self.browser_sessions.append(br)
+
+    def remove_browser(self, br):
+        self.browser_sessions = [browser for browser in self.browser_sessions if browser != br]
 
 
 browser_sessions = BrowserSessions()

--- a/seleniumtabs/schedule_tasks.py
+++ b/seleniumtabs/schedule_tasks.py
@@ -23,6 +23,7 @@ class BrowserTaskScheduler:
 
     def __init__(self):
         """Initialize the task scheduler"""
+        self._schedule = schedule.Scheduler()
         self._tasks = {}  # Store task references for cancellation
         self._tab_tasks = {}  # Store tasks by tab for easy lookup
         self._running = False
@@ -58,14 +59,14 @@ class BrowserTaskScheduler:
             return wrapper
 
         # Schedule the task and store its reference
-        job = schedule.every(period).seconds.do(task_decorator(task_func), tab, *args, **kwargs)
-        self._tasks[task_func.__name__] = job
+        job = self._schedule.every(period).seconds.do(task_decorator(task_func), tab, *args, **kwargs)
+        self._tasks.setdefault(task_func.__name__, []).append(job)
         self._task_status[task_func.__name__] = True  # Mark task as running
 
         # Store task by tab for easy lookup
         if tab not in self._tab_tasks:
             self._tab_tasks[tab] = []
-        self._tab_tasks[tab].append(task_func.__name__)
+        self._tab_tasks[tab].append((task_func.__name__, job))
 
         logger.info(f"Scheduled task {task_func.__name__} to run every {period} seconds")
 
@@ -79,14 +80,17 @@ class BrowserTaskScheduler:
             bool: True if task was cancelled, False if task not found
         """
         if task_name in self._tasks:
-            schedule.cancel_job(self._tasks[task_name])
-            del self._tasks[task_name]
+            for job in self._tasks.pop(task_name):
+                self._schedule.cancel_job(job)
             self._task_status[task_name] = False  # Mark task as not running
 
             # Remove task from tab_tasks
-            for tab_tasks in self._tab_tasks.values():
-                if task_name in tab_tasks:
-                    tab_tasks.remove(task_name)
+            for tab, tab_tasks in list(self._tab_tasks.items()):
+                remaining_tasks = [(name, job) for name, job in tab_tasks if name != task_name]
+                if remaining_tasks:
+                    self._tab_tasks[tab] = remaining_tasks
+                else:
+                    del self._tab_tasks[tab]
 
             logger.info(f"Cancelled task {task_name}")
             return True
@@ -110,14 +114,26 @@ class BrowserTaskScheduler:
             tab: The tab whose tasks should be cancelled
         """
         if tab in self._tab_tasks:
-            for task_name in self._tab_tasks[tab]:
-                self.cancel_task(task_name)
+            for task_name, job in list(self._tab_tasks[tab]):
+                self._schedule.cancel_job(job)
+                task_jobs = self._tasks.get(task_name, [])
+                if job in task_jobs:
+                    task_jobs.remove(job)
+
+                if task_jobs:
+                    self._task_status[task_name] = True
+                else:
+                    self._tasks.pop(task_name, None)
+                    self._task_status[task_name] = False
+
             del self._tab_tasks[tab]
             logger.info(f"Cancelled all tasks for tab {tab}")
 
     def cancel_all_tasks(self) -> None:
         """Cancel all scheduled tasks."""
-        schedule.clear()
+        for task_jobs in list(self._tasks.values()):
+            for job in task_jobs:
+                self._schedule.cancel_job(job)
         self._tasks.clear()
         self._tab_tasks.clear()
         self._task_status.clear()  # Clear all task statuses
@@ -145,7 +161,7 @@ class BrowserTaskScheduler:
             while self._running:
                 try:
                     # Check if any tabs are no longer alive and cancel their tasks
-                    schedule.run_pending()
+                    self._schedule.run_pending()
                 except Exception as e:
                     logger.error(f"Error during task execution: {str(e)}")
                     # Don't re-raise the exception - just log it and continue

--- a/seleniumtabs/session.py
+++ b/seleniumtabs/session.py
@@ -1,4 +1,7 @@
+import contextlib
 import logging
+from collections.abc import Callable
+from typing import Any
 
 from fake_useragent import UserAgent
 from selenium import webdriver
@@ -47,11 +50,16 @@ class Session:
         headless: bool = False,
         full_screen: bool = True,
         page_load_timeout: int = 60,
+        *,
+        driver_factory: Callable[[Any], webdriver.Chrome | webdriver.Firefox] | None = None,
+        options_factory: Callable[[str], Any] | None = None,
     ):
         self.browser = browser_name
 
         self.implicit_wait = implicit_wait
         self.page_load_timeout = page_load_timeout
+        self._driver_factory = driver_factory
+        self._options_factory = options_factory
 
         self.user_agent = user_agent or self.USER_AGENT_FUNCTIONS[self.browser].random
         self.headless = headless
@@ -76,13 +84,17 @@ class Session:
         """returns the driver/browser instance based on set variables and arguments"""
 
         driver_options = self._get_driver_options()
-        driver_func = self.BROWSER_DRIVER_FUNCTION[self.browser]
-        driver_service = self.BROWSER_DRIVER_SERVICE_FUNCTION[self.browser]
-        driver_manager = self.BROWSER_DRIVER_MANAGER_FUNCTION[self.browser]
 
-        driver: webdriver.Firefox | webdriver.Chrome = driver_func(
-            options=driver_options, service=driver_service(executable_path=driver_manager().install())
-        )
+        if self._driver_factory:
+            driver: webdriver.Firefox | webdriver.Chrome = self._driver_factory(driver_options)
+        else:
+            driver_func = self.BROWSER_DRIVER_FUNCTION[self.browser]
+            driver_service = self.BROWSER_DRIVER_SERVICE_FUNCTION[self.browser]
+            driver_manager = self.BROWSER_DRIVER_MANAGER_FUNCTION[self.browser]
+
+            driver = driver_func(
+                options=driver_options, service=driver_service(executable_path=driver_manager().install())
+            )
 
         driver.implicitly_wait(self.implicit_wait)
 
@@ -92,6 +104,9 @@ class Session:
         return driver
 
     def _get_driver_options(self):
+        if self._options_factory:
+            return self._options_factory(self.browser)
+
         driver_options = self.BROWSER_OPTION_FUNCTION[self.browser]()
 
         if self.headless:
@@ -167,7 +182,8 @@ class Session:
             self._driver = None
 
     def __del__(self) -> None:
-        self.close()
+        with contextlib.suppress(Exception):
+            self.close()
 
     def _log_session_info(self) -> None:
         """Log information about the browser session."""

--- a/seleniumtabs/settings.py
+++ b/seleniumtabs/settings.py
@@ -42,6 +42,3 @@ def setup_logging(path: str | Path = BASE_DIR / LOG_CONF_FILE, default_level: in
     else:
         logging.basicConfig(level=default_level)
         logging.warning(f"Logging config file not found at {path}. Using basic config.")
-
-
-setup_logging()

--- a/seleniumtabs/tabs.py
+++ b/seleniumtabs/tabs.py
@@ -3,7 +3,7 @@ import logging
 import random
 import time
 from collections import OrderedDict
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from threading import Lock
 from typing import Any
 
@@ -21,7 +21,8 @@ from seleniumtabs.browser_management import browser_sessions
 from seleniumtabs.css_selectors import SelectableCSS
 from seleniumtabs.exceptions import SeleniumOpenTabException, SeleniumRequestException
 from seleniumtabs.js_scripts import scripts
-from seleniumtabs.schedule_tasks import task_scheduler
+from seleniumtabs.schedule_tasks import BrowserTaskScheduler
+from seleniumtabs.schedule_tasks import task_scheduler as default_task_scheduler
 from seleniumtabs.session import Session
 from seleniumtabs.utils.urls import get_domain
 from seleniumtabs.wait import humanized_wait
@@ -36,11 +37,21 @@ class Tab:
 
     SCROLL_DIST = 50
 
-    def __init__(self, session: Session, tab_handle, start_url: str | None = None, full_screen: bool = True):
+    def __init__(
+        self,
+        session: Session,
+        tab_handle,
+        start_url: str | None = None,
+        full_screen: bool = True,
+        task_scheduler: BrowserTaskScheduler | None = None,
+        close_tab: Callable[["Tab"], bool | None] | None = None,
+    ):
         self._session = session
         self.tab_handle = tab_handle
         self.start_url = start_url
         self.full_screen = full_screen
+        self._task_scheduler = task_scheduler or default_task_scheduler
+        self._close_tab = close_tab
 
     @property
     def driver(self) -> webdriver.Chrome | webdriver.Firefox:
@@ -74,7 +85,8 @@ class Tab:
             return getattr(self.driver, item)
 
     def __del__(self):
-        self.close()
+        with contextlib.suppress(Exception):
+            self.close()
 
     def __hash__(self):
         return hash(self.tab_handle)
@@ -237,7 +249,13 @@ class Tab:
         raise SeleniumOpenTabException(f"Could not open {url} - neither full nor partial load succeeded")
 
     def close(self):
-        browser_sessions.close_tab(self)
+        if self._close_tab:
+            return self._close_tab(self)
+
+        if browser := browser_sessions.get_browser_for_tab(self):
+            return browser.close_tab(self)
+
+        raise SeleniumRequestException("Tab is not owned by an active Browser.")
 
     def click(self, element: webelement.WebElement) -> bool:
         """Click a given element on the page represented by the tab"""
@@ -535,7 +553,7 @@ class Tab:
         return self.pyquery
 
     def schedule_task(self, task, period: int, *args, **kwargs):
-        task_scheduler.schedule_task(self, task, period, *args, **kwargs)
+        self._task_scheduler.schedule_task(self, task, period, *args, **kwargs)
 
 
 class TabManager:
@@ -548,9 +566,16 @@ class TabManager:
     - Handling tab operations (open, close, switch)
     """
 
-    def __init__(self, session: Session):
+    def __init__(
+        self,
+        session: Session,
+        task_scheduler: BrowserTaskScheduler | None = None,
+        close_tab: Callable[[Tab], bool | None] | None = None,
+    ):
         self._session = session
         self._all_tabs = OrderedDict()
+        self._task_scheduler = task_scheduler or default_task_scheduler
+        self._close_tab = close_tab
 
     def __iter__(self) -> Iterator[Tab]:
         """Make TabManager iterable by yielding tab values"""
@@ -628,7 +653,13 @@ class TabManager:
     def create(self, tab_handle, full_screen: bool = True) -> Tab:
         """Create a Tab object"""
 
-        tab = Tab(session=self._session, tab_handle=tab_handle, full_screen=full_screen)
+        tab = Tab(
+            session=self._session,
+            tab_handle=tab_handle,
+            full_screen=full_screen,
+            task_scheduler=self._task_scheduler,
+            close_tab=self._close_tab,
+        )
         self.add(tab)
         return tab
 
@@ -693,7 +724,7 @@ class TabManager:
         curr_tab = self.current_tab()
         curr_tabs = set(self._all_tabs)
         tabs = [
-            Tab(session=self._session, tab_handle=handle)
+            Tab(session=self._session, tab_handle=handle, task_scheduler=self._task_scheduler)
             for handle in self._session.window_handles
             if handle not in curr_tabs
         ]

--- a/tests/test_schedule_tasks.py
+++ b/tests/test_schedule_tasks.py
@@ -1,3 +1,5 @@
+import schedule
+
 from seleniumtabs.schedule_tasks import BrowserTaskScheduler
 
 
@@ -52,3 +54,48 @@ def test_cancel_task_returns_false_for_unknown_task():
     scheduler = BrowserTaskScheduler()
 
     assert scheduler.cancel_task("missing") is False
+
+
+def test_cancel_all_tasks_leaves_unowned_schedule_jobs_intact():
+    scheduler = BrowserTaskScheduler()
+    tab = DummyTab()
+
+    def scheduler_task(tab):
+        return None
+
+    def unowned_task():
+        return None
+
+    try:
+        unowned_job = schedule.every(60).seconds.do(unowned_task)
+        scheduler.schedule_task(tab, scheduler_task, period=60)
+
+        scheduler.cancel_all_tasks()
+
+        assert unowned_job in schedule.jobs
+    finally:
+        schedule.clear()
+
+
+def test_cancel_tab_tasks_preserves_same_named_task_on_other_tabs():
+    scheduler = BrowserTaskScheduler()
+    first = DummyTab()
+    second = DummyTab()
+    calls = []
+
+    def collect(tab):
+        calls.append(tab)
+
+    try:
+        scheduler.schedule_task(first, collect, period=0.01)
+        scheduler.schedule_task(second, collect, period=0.01)
+
+        scheduler.cancel_tab_tasks(first)
+        scheduler.execute_tasks(max_time=0.05, sleep_time=0.01)
+
+        assert calls == [second]
+        assert first.switch_count == 0
+        assert second.switch_count == 1
+        assert scheduler.is_task_running("collect") is True
+    finally:
+        scheduler.cancel_all_tasks()

--- a/tests/test_session_cleanup.py
+++ b/tests/test_session_cleanup.py
@@ -1,3 +1,4 @@
+import pytest
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 
@@ -11,14 +12,119 @@ def test_session_destructor_ignores_missing_driver_after_failed_initialization()
     assert session.__del__() is None
 
 
+def test_session_destructor_suppresses_close_errors():
+    session = Session.__new__(Session)
+
+    def fail_close():
+        raise RuntimeError("close failed")
+
+    session.close = fail_close
+
+    assert session.__del__() is None
+
+
 def test_session_builds_chrome_and_firefox_options_without_launching_driver():
     for browser_name, expected_type in (("Chrome", ChromeOptions), ("FireFox", FirefoxOptions)):
         session = Session.__new__(Session)
         session.browser = browser_name
         session.headless = True
         session.user_agent = "seleniumtabs-test-agent"
+        session._options_factory = None
 
         assert isinstance(session._get_driver_options(), expected_type)
+
+
+def test_session_accepts_driver_and_options_factories_without_launching_browser():
+    calls = {}
+
+    class FakeDriver:
+        capabilities = {"browserName": "fake", "browserVersion": "1", "platformName": "test"}
+
+        def __init__(self):
+            self.implicit_wait = None
+            self.page_load_timeout = None
+            self.closed = False
+
+        def implicitly_wait(self, value):
+            self.implicit_wait = value
+
+        def set_page_load_timeout(self, value):
+            self.page_load_timeout = value
+
+        def quit(self):
+            self.closed = True
+
+    fake_driver = FakeDriver()
+
+    def options_factory(browser_name):
+        calls["options_browser"] = browser_name
+        return ChromeOptions()
+
+    def driver_factory(options):
+        calls["driver_options"] = options
+        return fake_driver
+
+    session = Session(
+        "Chrome",
+        implicit_wait=4,
+        user_agent="seleniumtabs-test-agent",
+        full_screen=False,
+        page_load_timeout=9,
+        options_factory=options_factory,
+        driver_factory=driver_factory,
+    )
+
+    try:
+        assert session.driver is fake_driver
+        assert calls["options_browser"] == "Chrome"
+        assert calls["driver_options"] is not None
+        assert fake_driver.implicit_wait == 4
+        assert fake_driver.page_load_timeout == 9
+    finally:
+        session.close()
+
+
+def test_browser_forwards_driver_and_options_factories_to_session(monkeypatch):
+    created_session = {}
+
+    def driver_factory(options):
+        return options
+
+    def options_factory(browser_name):
+        return browser_name
+
+    class RecordingSession:
+        def __init__(
+            self,
+            browser_name,
+            implicit_wait,
+            user_agent,
+            headless=False,
+            full_screen=True,
+            page_load_timeout=60,
+            driver_factory=None,
+            options_factory=None,
+        ):
+            created_session.update(
+                {
+                    "driver_factory": driver_factory,
+                    "options_factory": options_factory,
+                }
+            )
+
+        def close(self):
+            created_session["closed"] = True
+
+    monkeypatch.setattr(browser_module, "Session", RecordingSession)
+
+    browser = browser_module.Browser(name="Chrome", driver_factory=driver_factory, options_factory=options_factory)
+    browser.close()
+
+    assert created_session == {
+        "driver_factory": driver_factory,
+        "options_factory": options_factory,
+        "closed": True,
+    }
 
 
 def test_browser_forwards_page_load_timeout_to_session(monkeypatch):
@@ -62,3 +168,98 @@ def test_browser_forwards_page_load_timeout_to_session(monkeypatch):
         "page_load_timeout": 7,
         "closed": True,
     }
+
+
+def test_browser_instances_have_independent_task_schedulers(monkeypatch):
+    class RecordingSession:
+        def __init__(
+            self,
+            browser_name,
+            implicit_wait,
+            user_agent,
+            headless=False,
+            full_screen=True,
+            page_load_timeout=60,
+        ):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(browser_module, "Session", RecordingSession)
+
+    first = browser_module.Browser(name="Chrome")
+    second = browser_module.Browser(name="Chrome")
+    try:
+        assert first.task_scheduler is not second.task_scheduler
+    finally:
+        first.close()
+        second.close()
+
+
+def test_browser_close_is_idempotent(monkeypatch):
+    close_calls = []
+
+    class RecordingSession:
+        def __init__(
+            self,
+            browser_name,
+            implicit_wait,
+            user_agent,
+            headless=False,
+            full_screen=True,
+            page_load_timeout=60,
+        ):
+            return None
+
+        def close(self):
+            close_calls.append("closed")
+
+    monkeypatch.setattr(browser_module, "Session", RecordingSession)
+
+    browser = browser_module.Browser(name="Chrome")
+    browser.close()
+    browser.close()
+
+    assert close_calls == ["closed"]
+
+
+def test_browser_destructor_suppresses_close_errors():
+    browser = browser_module.Browser.__new__(browser_module.Browser)
+
+    def fail_close():
+        raise RuntimeError("close failed")
+
+    browser.close = fail_close
+
+    assert browser.__del__() is None
+
+
+def test_browser_close_removes_registry_entry_when_session_close_fails(monkeypatch):
+    class FailingSession:
+        def __init__(
+            self,
+            browser_name,
+            implicit_wait,
+            user_agent,
+            headless=False,
+            full_screen=True,
+            page_load_timeout=60,
+        ):
+            return None
+
+        def close(self):
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(browser_module, "Session", FailingSession)
+
+    browser = browser_module.Browser(name="Chrome")
+    try:
+        assert browser in browser_module.browser_sessions.browser_sessions
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            browser.close()
+
+        assert browser not in browser_module.browser_sessions.browser_sessions
+    finally:
+        browser_module.browser_sessions.remove_browser(browser)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -21,3 +21,24 @@ def test_element_center_returns_midpoint_from_location_and_size():
         size = {"width": 30, "height": 40}
 
     assert Tab.element_center(Element()) == {"x": 25.0, "y": 40.0}
+
+
+def test_tab_close_uses_explicit_owner_callback(monkeypatch):
+    closed_tabs = []
+    tab = Tab(ClosedSession(), "missing", close_tab=closed_tabs.append)
+
+    def fail_global_close(tab):
+        raise AssertionError("Tab.close() should not use the global browser registry")
+
+    monkeypatch.setattr("seleniumtabs.tabs.browser_sessions.close_tab", fail_global_close)
+
+    assert tab.close() is None
+    assert closed_tabs == [tab]
+
+
+def test_unowned_tab_close_raises_request_exception(monkeypatch):
+    tab = Tab(ClosedSession(), "missing")
+    monkeypatch.setattr("seleniumtabs.tabs.browser_sessions.get_browser_for_tab", lambda tab: None)
+
+    with pytest.raises(SeleniumRequestException, match="Tab is not owned"):
+        tab.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+import importlib
+import logging
+import sys
+
 import pytest
 from selenium.webdriver.common.by import By
 
@@ -63,3 +67,32 @@ def test_find_parent_element_uses_parent_xpath():
             return "parent"
 
     assert core.find_parent_element(Element()) == "parent"
+
+
+def test_importing_settings_does_not_configure_logging_or_create_logs_dir(tmp_path, monkeypatch):
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    previous_settings = sys.modules.pop("seleniumtabs.settings", None)
+
+    for handler in original_handlers:
+        root_logger.removeHandler(handler)
+
+    monkeypatch.chdir(tmp_path)
+
+    try:
+        importlib.import_module("seleniumtabs.settings")
+
+        assert root_logger.handlers == []
+        assert not (tmp_path / "logs").exists()
+    finally:
+        sys.modules.pop("seleniumtabs.settings", None)
+        if previous_settings is not None:
+            sys.modules["seleniumtabs.settings"] = previous_settings
+
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+            handler.close()
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        root_logger.setLevel(original_level)

--- a/uv.lock
+++ b/uv.lock
@@ -823,7 +823,7 @@ wheels = [
 
 [[package]]
 name = "seleniumtabs"
-version = "2.1.2"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "browserjquery" },


### PR DESCRIPTION
## Summary
- Bump package metadata from 2.1.2 to 2.2.0.
- Scope scheduled tasks to each Browser instance and route managed Tab.close through explicit ownership.
- Harden cleanup behavior, add Session/Browser factory hooks, and make logging setup opt-in.

## Test plan
- make check-commit
- make build
- SELENIUMTABS_FAIL_BROWSER_SKIP=1 uv run pytest tests/test_local_browser.py -q


Made with [Cursor](https://cursor.com)